### PR TITLE
Fix setting wrong component type to 'Failed'

### DIFF
--- a/src/read/package.rs
+++ b/src/read/package.rs
@@ -109,6 +109,6 @@ pub fn package_count(fail: &mut Fail) -> String {
             .trim()
             .to_string();
     }
-    fail.battery.fail_component();
+    fail.packages.fail_component();
     return String::from("0");
 }


### PR DESCRIPTION
This PR fixes a mistake, where the wrong component will be marked as failed (battery) when getting the package count.