### PR TITLE
Add `packages` support to Void Linux

### DIFF
--- a/src/read/package.rs
+++ b/src/read/package.rs
@@ -76,9 +76,32 @@ pub fn package_count(fail: &mut Fail) -> String {
             .expect("ERROR: \"dpkg -l | wc -l\" output was not valid UTF-8")
             .trim()
             .to_string();
-    }
-    fail.packages.fail_component();
-    return String::from("0");
+    } else if extra::which("xbps-query") {
+        let xbps = Command::new("xbps-query")
+        .arg("-l")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("ERROR: failed to start \"xbps-query\" process");
+
+        let xbps_out = xbps.stdout.expect("ERROR: failed to open \"xbps-query\" stdout");
+
+        let count = Command::new("wc")
+            .arg("-l")
+            .stdin(Stdio::from(xbps_out))
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("ERROR: failed to start \"wc\" process");
+
+        let output = count
+            .wait_with_output()
+            .expect("ERROR: failed to wait for \"wc\" process to exit");
+        return String::from_utf8(output.stdout)
+            .expect("ERROR: \"xbps-query -l | wc -l\" output was not valid UTF-8")
+            .trim()
+            .to_string();
+        }
+        fail.packages.fail_component();
+        return String::from("0");
 }
 
 #[cfg(target_os = "netbsd")]

--- a/src/read/package.rs
+++ b/src/read/package.rs
@@ -4,8 +4,8 @@ use std::process::{Command, Stdio};
 #[cfg(target_os = "linux")]
 /// Extract package count for debian-based, arch-based distros or NetBSD
 pub fn package_count(fail: &mut Fail) -> String {
-    // Instead of having a condition for the millions of distros.
-    // This function will try and extract package count by checking
+    // Instead of having a condition for each distribution,
+    // we will try and extract package count by checking
     // if a certain package manager is installed
     if extra::which("pacman") {
         let pacman = Command::new("pacman")
@@ -55,7 +55,7 @@ pub fn package_count(fail: &mut Fail) -> String {
             .to_string();
     } else if extra::which("emerge") {
         let ls = Command::new("ls")
-            .arg("/var/db/pkg/*")
+            .arg("/var/db/pkg")
             .stdout(Stdio::piped())
             .spawn()
             .expect("ERROR: failed to start \"ls\" process");
@@ -73,7 +73,7 @@ pub fn package_count(fail: &mut Fail) -> String {
             .wait_with_output()
             .expect("ERROR: failed to wait for \"wc\" process to exit");
         return String::from_utf8(output.stdout)
-            .expect("ERROR: \"dpkg -l | wc -l\" output was not valid UTF-8")
+            .expect("ERROR: \"ls /var/db/pkg | wc -l\" output was not valid UTF-8")
             .trim()
             .to_string();
     } else if extra::which("xbps-query") {
@@ -105,7 +105,7 @@ pub fn package_count(fail: &mut Fail) -> String {
             .wait_with_output()
             .expect("ERROR: failed to wait for \"wc\" process to exit");
         return String::from_utf8(output.stdout)
-            .expect("ERROR: \"xbps-query -l | wc -l\" output was not valid UTF-8")
+            .expect("ERROR: \"xbps-query -l | grep ii | wc -l\" output was not valid UTF-8")
             .trim()
             .to_string();
         }

--- a/src/read/package.rs
+++ b/src/read/package.rs
@@ -85,9 +85,18 @@ pub fn package_count(fail: &mut Fail) -> String {
 
         let xbps_out = xbps.stdout.expect("ERROR: failed to open \"xbps-query\" stdout");
 
+        let grep = Command::new("grep")
+        .arg("ii")
+        .stdin(Stdio::from(xbps_out))
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("ERROR: failed to start \"grep\" process");
+
+        let grep_out = grep.stdout.expect("ERROR: failed to read \"grep\" stdout");
+
         let count = Command::new("wc")
             .arg("-l")
-            .stdin(Stdio::from(xbps_out))
+            .stdin(Stdio::from(grep_out))
             .stdout(Stdio::piped())
             .spawn()
             .expect("ERROR: failed to start \"wc\" process");


### PR DESCRIPTION
This patch adds support for `packages` on Void Linux by using the pipeline `xbps-query -l | grep ii | wc -l`
It _would_ be better with `grep -E` or `egrep`, but it's not given that they'll be there.
I'm new to rust, so if I made a fundamental mistake, _sorry_.
