### PR TITLE
macchina-read: more robust distribution detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "nix",
  "objc",
  "objc-foundation",
+ "os-release",
  "sysctl",
  "windows",
 ]
@@ -311,6 +312,15 @@ name = "object"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+
+[[package]]
+name = "os-release"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/macchina-read/Cargo.toml
+++ b/macchina-read/Cargo.toml
@@ -16,6 +16,7 @@ windows = "0.4.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "netbsd"))'.dependencies]
 nix = "0.20.0"
+os-release = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.1"

--- a/macchina-read/Cargo.toml
+++ b/macchina-read/Cargo.toml
@@ -16,6 +16,8 @@ windows = "0.4.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "netbsd"))'.dependencies]
 nix = "0.20.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 os-release = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -31,25 +31,10 @@ pub(crate) fn uptime() -> Result<String, ReadoutError> {
 /// Read distribution name from `/etc/os-release`
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 pub(crate) fn distribution() -> Result<String, ReadoutError> {
-    let content = fs::File::open("/etc/os-release")?;
+    use os_release::OsRelease;
+    let content = OsRelease::new()?;
 
-    let head = Command::new("head")
-        .args(&["-n", "1"])
-        .stdin(Stdio::from(content))
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("ERROR: failed to start \"head\" process");
-
-    let output = head
-        .wait_with_output()
-        .expect("ERROR: failed to wait for \"head\" process to exit");
-
-    let distribution =
-        String::from_utf8(output.stdout).expect("ERROR: \"ps\" process stdout was not valid UTF-8");
-
-    Ok(extra::pop_newline(
-        distribution.replace("\"", "").replace("NAME=", ""),
-    ))
+    Ok(content.name)
 }
 
 /// Read desktop environment name from `DESKTOP_SESSION` environment variable


### PR DESCRIPTION
This Pull Request should fix a situation where the first line of the `os-release` file is not `NAME`.

FD.o didn't specify in which order the fields should appear (https://www.freedesktop.org/software/systemd/man/os-release.html) so this should fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grtcdr/macchina/27)
<!-- Reviewable:end -->
