### PR TITLE
Use sysctl library instead of spawning process

### DIFF
--- a/macchina-read/Cargo.toml
+++ b/macchina-read/Cargo.toml
@@ -21,9 +21,11 @@ os-release = "0.1"
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.1"
 mach = "0.3.2"
-sysctl = "0.4.0"
 objc = "0.2.7"
 objc-foundation = "0.1.1"
+
+[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
+sysctl = "0.4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = "0.4.0"

--- a/macchina-read/src/macos/mod.rs
+++ b/macchina-read/src/macos/mod.rs
@@ -13,15 +13,9 @@ use mach::kern_return::KERN_SUCCESS;
 use objc::runtime::Object;
 use objc_foundation::{INSString, NSString};
 use std::ffi::CString;
-use sysctl::{Ctl, Sysctl, SysctlError};
+use sysctl::{Ctl, Sysctl};
 
 mod mach_ffi;
-
-impl From<SysctlError> for ReadoutError {
-    fn from(e: SysctlError) -> Self {
-        ReadoutError::Other(format!("Error while accessing system control: {:?}", e))
-    }
-}
 
 pub struct MacOSBatteryReadout {
     power_info: Option<MacOSIOPMPowerSource>,

--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -4,6 +4,9 @@ use std::ffi::CStr;
 use std::io::Error;
 use std::path::Path;
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use sysctl::SysctlError;
+
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 use crate::extra;
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
@@ -16,6 +19,12 @@ use std::{env, fs};
 impl From<std::io::Error> for ReadoutError {
     fn from(e: Error) -> Self {
         ReadoutError::Other(e.to_string())
+    }
+}
+
+impl From<SysctlError> for ReadoutError {
+    fn from(e: SysctlError) -> Self {
+        ReadoutError::Other(format!("Error while accessing system control: {:?}", e))
     }
 }
 


### PR DESCRIPTION
As written in https://github.com/grtcdr/macchina/issues/28#issuecomment-798472740, it's better to use the native library for getting sysctl values instead of spawning a new process for each value.