### PR TITLE
Remove objc runtime, use sysctl instead to get os version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,8 +215,6 @@ dependencies = [
  "libc",
  "mach",
  "nix",
- "objc",
- "objc-foundation",
  "os-release",
  "sysctl",
  "windows",
@@ -233,15 +225,6 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
@@ -276,35 +259,6 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
-]
-
-[[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
 ]
 
 [[package]]

--- a/macchina-read/Cargo.toml
+++ b/macchina-read/Cargo.toml
@@ -21,8 +21,6 @@ os-release = "0.1"
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.1"
 mach = "0.3.2"
-objc = "0.2.7"
-objc-foundation = "0.1.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 sysctl = "0.4.0"

--- a/macchina-read/src/lib.rs
+++ b/macchina-read/src/lib.rs
@@ -1,9 +1,5 @@
 use cfg_if::cfg_if;
 
-#[cfg(target_os = "macos")]
-#[macro_use]
-extern crate objc;
-
 cfg_if! {
     if #[cfg(target_os = "linux")] {
         mod linux;

--- a/macchina-read/src/macos/mach_ffi.rs
+++ b/macchina-read/src/macos/mach_ffi.rs
@@ -12,7 +12,6 @@ use core_foundation::base::{mach_port_t, CFAllocatorRef, CFRelease, CFTypeRef, T
 use core_foundation::dictionary::{CFDictionaryRef, CFMutableDictionaryRef};
 use core_foundation::string::CFStringRef;
 use libc::c_char;
-use objc_foundation::NSString;
 use std::os::raw::c_uint;
 
 type host_flavor_t = integer_t;


### PR DESCRIPTION
This PR removes the Objective-C runtime which was only used for getting the version string of the OS. This string can be retrieved using sysctl. 

Removing the objective-c code and using the sysctl instead brings a speed boost of about 3ms (from 8ms with obj-c down to 4.8ms).