### PR TITLE
🎛 Use type-safe command line parsing with StructOpt and Clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +213,7 @@ dependencies = [
  "macchina-read",
  "num_cpus",
  "rand",
+ "structopt",
 ]
 
 [[package]]
@@ -281,6 +291,30 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -368,6 +402,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +493,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "walkdir"

--- a/macchina/Cargo.toml
+++ b/macchina/Cargo.toml
@@ -14,6 +14,7 @@ colored = "2.0.0"
 num_cpus = "1.13.0"
 bytesize = "1.0.1"
 clap = "2.33.3"
+structopt = "0.3.21"
 rand = "0.8.3"
 lazy_static = "1.4.0"
 macchina-read = { version = "0.1.1", path = "../macchina-read" }

--- a/macchina/src/display.rs
+++ b/macchina/src/display.rs
@@ -1030,10 +1030,10 @@ pub fn unhide(
     elems.battery.hidden = !hide_parameters.contains(&ReadoutKey::Battery);
 
     if let Some(true) = elems.is_running_wm_only(fail, false) {
-        elems.desktop_environment.hidden = hide_parameters.contains(&ReadoutKey::Distribution);
+        elems.desktop_environment.hidden = hide_parameters.contains(&ReadoutKey::DesktopEnvironment);
         elems.window_manager.hidden = !hide_parameters.contains(&ReadoutKey::WindowManager);
     } else {
-        elems.desktop_environment.hidden = !hide_parameters.contains(&ReadoutKey::Distribution);
+        elems.desktop_environment.hidden = !hide_parameters.contains(&ReadoutKey::DesktopEnvironment);
         elems.window_manager.hidden = !hide_parameters.contains(&ReadoutKey::WindowManager);
     }
 

--- a/macchina/src/display.rs
+++ b/macchina/src/display.rs
@@ -60,8 +60,8 @@ impl Fail {
             ),
             battery: FailedComponent::new(
                 false,
-                String::from("(ERROR:DISABLED) Battery -> 
-                (Linux) 
+                String::from("(ERROR:DISABLED) Battery ->
+                (Linux)
                 Percentage extracted from /sys/class/power_supply/BATx/capacity
                 Status extracted from /sys/class/power_supply/BATx/status
                 (NetBSD) (ripgrep is required)
@@ -74,7 +74,7 @@ impl Fail {
             ),
             host: FailedComponent::new(
                 false,
-                String::from("(ERROR:DISABLED) Host -> 
+                String::from("(ERROR:DISABLED) Host ->
                 Hostname: Obtained from nix::unistd::gethostname()
                 Username: Obtained from whoami"),
             ),
@@ -88,7 +88,7 @@ impl Fail {
             ),
             packages: FailedComponent::new(
                 false,
-                String::from("(ERROR:DISABLED) Packages -> 
+                String::from("(ERROR:DISABLED) Packages ->
                 (Arch-based distros) Extracted using \"pacman -Qq | wc -l\"
                 (Debian-based distros) Extracted using \"dpkg -l | wc -l\"
                 (Gentoo) Extracted using \"qlist -I | wc -l\"
@@ -411,7 +411,7 @@ impl Elements {
 ///        if self.example.hidden {
 ///            return;
 ///        }
-///        
+///
 ///        // Fetch the element's value
 ///        // If an error occurs during this process then fail the element and exit
 ///        match format::example() {
@@ -424,7 +424,7 @@ impl Elements {
 ///
 ///        // Now it's time to print the key, separator and value
 ///        println!(
-///        //...    
+///        //...
 ///        );
 ///    }
 /// ```
@@ -488,7 +488,7 @@ impl Display for Elements {
                         .key(ReadoutKey::Host, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.host.value
         );
@@ -515,7 +515,7 @@ impl Display for Elements {
                         .key(ReadoutKey::Machine, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.machine.value
         );
@@ -542,7 +542,7 @@ impl Display for Elements {
                         .key(ReadoutKey::Kernel, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.kernel.value
         );
@@ -567,7 +567,7 @@ impl Display for Elements {
                 ReadoutKey::OperatingSystem,
                 self.theme.default_abbreviation()
             ),)),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.operating_system.value
         );
@@ -597,7 +597,7 @@ impl Display for Elements {
                         .key(ReadoutKey::Distribution, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.distribution.value
         );
@@ -629,7 +629,7 @@ impl Display for Elements {
                 ReadoutKey::DesktopEnvironment,
                 self.theme.default_abbreviation()
             ))),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.desktop_environment.value
         );
@@ -659,7 +659,7 @@ impl Display for Elements {
                         .key(ReadoutKey::WindowManager, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.window_manager.value
         );
@@ -689,7 +689,7 @@ impl Display for Elements {
                         .key(ReadoutKey::Packages, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.packages.value
         );
@@ -711,7 +711,7 @@ impl Display for Elements {
                         .key(ReadoutKey::Shell, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.shell.value
         );
@@ -741,7 +741,7 @@ impl Display for Elements {
                         .key(ReadoutKey::Terminal, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.terminal.value
         );
@@ -768,7 +768,7 @@ impl Display for Elements {
                         .key(ReadoutKey::Processor, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.processor.value
         );
@@ -790,7 +790,7 @@ impl Display for Elements {
                         .key(ReadoutKey::Uptime, self.theme.default_abbreviation())
                 )
             ),
-            self.theme.misc().separator,
+            self.theme.get_colored_separator(),
             self.theme.spacing(),
             self.uptime.value
         );
@@ -825,7 +825,7 @@ impl Display for Elements {
                             .key(ReadoutKey::Memory, self.theme.default_abbreviation())
                     )
                 ),
-                self.theme.misc().separator,
+                self.theme.get_colored_separator(),
                 self.theme.spacing(),
             );
             Self::print_bar(self, self.memory.value.parse().unwrap());
@@ -841,7 +841,7 @@ impl Display for Elements {
                             .key(ReadoutKey::Memory, self.theme.default_abbreviation())
                     )
                 ),
-                self.theme.misc().separator,
+                self.theme.get_colored_separator(),
                 self.theme.spacing(),
                 self.memory.value
             );
@@ -873,7 +873,7 @@ impl Display for Elements {
                             .key(ReadoutKey::Battery, self.theme.default_abbreviation())
                     )
                 ),
-                self.theme.misc().separator,
+                self.theme.get_colored_separator(),
                 self.theme.spacing(),
             );
 
@@ -890,7 +890,7 @@ impl Display for Elements {
                             .key(ReadoutKey::Battery, self.theme.default_abbreviation())
                     )
                 ),
-                self.theme.misc().separator,
+                self.theme.get_colored_separator(),
                 self.theme.spacing(),
                 self.battery.value
             );

--- a/macchina/src/display.rs
+++ b/macchina/src/display.rs
@@ -238,6 +238,9 @@ impl Elements {
         if !self.terminal.hidden {
             keys.push(self.theme.key(ReadoutKey::Terminal, abbrev).to_string());
         }
+        if !self.operating_system.hidden {
+            keys.push(self.theme.key(ReadoutKey::OperatingSystem, abbrev).to_string());
+        }
         if !self.processor.hidden {
             keys.push(self.theme.key(ReadoutKey::Processor, abbrev).to_string());
         }
@@ -272,6 +275,7 @@ impl Elements {
                 );
             }
         }
+
         let mut longest_key = keys[0].to_string();
         for val in keys {
             if val.len() > longest_key.len() {

--- a/macchina/src/main.rs
+++ b/macchina/src/main.rs
@@ -169,9 +169,10 @@ fn main() {
     let mut fail = Fail::new();
     elems.set_theme(opt.theme.create_instance(), &mut fail);
 
+    let longest_key = elems.longest_key(&mut fail);
     let mut misc = elems.theme.misc_mut();
 
-
+    misc.longest_key = longest_key;
     misc.padding = opt.padding;
     misc.color = opt.color.get_color();
     misc.separator_color = opt.separator_color.get_color();

--- a/macchina/src/main.rs
+++ b/macchina/src/main.rs
@@ -3,25 +3,20 @@ mod display;
 mod format;
 mod theme;
 
-use clap::{crate_authors, crate_version, App, Arg};
+use clap::arg_enum;
+use clap::crate_authors;
 use colored::Color;
-use display::{choose_color, Elements, Fail, Options};
-use macchina_read::{extra, Readouts};
-use theme::Theme;
+use display::{Elements, Fail};
+use macchina_read::Readouts;
+use structopt::StructOpt;
 
 #[macro_use]
 extern crate lazy_static;
 
 use macchina_read::traits::*;
 
-/// Macchina's version
-pub const VERSION: &str = crate_version!();
-/// Macchina's default color
-pub const DEFAULT_COLOR: Color = Color::Blue;
-/// Macchina's default separator color
-pub const DEFAULT_SEPARATOR_COLOR: Color = Color::White;
-/// Macchina's default padding value
-pub const DEFAULT_PADDING: usize = 4;
+pub const AUTHORS: &str = crate_authors!();
+pub const ABOUT: &str = "System information fetcher";
 
 lazy_static! {
     pub(crate) static ref READOUTS: Readouts = Readouts {
@@ -34,214 +29,186 @@ lazy_static! {
     };
 }
 
+arg_enum! {
+    #[derive(Debug)]
+    pub enum MacchinaColor {
+        Red,
+        Green,
+        Blue,
+        Yellow,
+        Cyan,
+        Magenta,
+        Black,
+        White
+    }
+}
+
+impl MacchinaColor {
+    /// Convert arguments passed to `--color` to their respective color.
+    fn get_color(&self) -> Color {
+        match self {
+            MacchinaColor::Red => Color::Red,
+            MacchinaColor::Green => Color::Green,
+            MacchinaColor::Blue => Color::Blue,
+            MacchinaColor::Yellow => Color::Yellow,
+            MacchinaColor::Cyan => Color::Cyan,
+            MacchinaColor::Magenta => Color::Magenta,
+            MacchinaColor::Black => Color::Black,
+            MacchinaColor::White => Color::White,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(author = AUTHORS, about = ABOUT)]
+pub struct Opt {
+    #[structopt(short = "p", long = "palette", help = "Displays color palette")]
+    palette: bool,
+
+    #[structopt(
+        short = "P",
+        long = "padding",
+        default_value = "4",
+        help = "Specifies the amount of left padding to use"
+    )]
+    padding: usize,
+
+    #[structopt(
+        short = "s",
+        long = "spacing",
+        help = "Specifies the amount of spacing to use"
+    )]
+    spacing: Option<usize>,
+
+    #[structopt(short = "n", long = "no-color", help = "Disables color")]
+    no_color: bool,
+
+    #[structopt(
+        short = "c",
+        long = "color",
+        possible_values = &MacchinaColor::variants(),
+        case_insensitive = true,
+        default_value = "Blue",
+        help = "Specifies the key color"
+    )]
+    color: MacchinaColor,
+
+    #[structopt(
+        short = "b",
+        long = "bar",
+        help = "Displays bars instead of numerical values"
+    )]
+    bar: bool,
+
+    #[structopt(
+        short = "C",
+        long = "separator-color",
+        possible_values = &MacchinaColor::variants(),
+        case_insensitive = true,
+        default_value = "White",
+        help = "Specifies the separator color"
+    )]
+    separator_color: MacchinaColor,
+
+    #[structopt(
+        short = "r",
+        long = "random-color",
+        help = "Picks a random key color for you"
+    )]
+    random_color: bool,
+
+    #[structopt(
+        short = "R",
+        long = "random-sep-color",
+        help = "Picks a random separator color for you"
+    )]
+    random_sep_color: bool,
+
+    #[structopt(
+        short = "H",
+        long = "hide",
+        possible_values = &theme::ReadoutKey::variants(),
+        case_insensitive = true,
+        help = "Hides the specified elements"
+    )]
+    hide: Option<Vec<theme::ReadoutKey>>,
+
+    #[structopt(
+        short = "X",
+        long = "show-only",
+        possible_values = &theme::ReadoutKey::variants(),
+        case_insensitive = true,
+        help = " Displays only the specified elements"
+    )]
+    show_only: Option<Vec<theme::ReadoutKey>>,
+
+    #[structopt(short = "d", long = "debug", help = "Prints debug information")]
+    debug: bool,
+
+    #[structopt(short = "U", long = "short-uptime", help = "Shortens uptime output")]
+    short_uptime: bool,
+
+    #[structopt(short = "S", long = "short-shell", help = "Shortens shell output")]
+    short_shell: bool,
+
+    #[structopt(
+        short = "t",
+        long = "theme",
+        default_value = "Hydrogen",
+        possible_values = &theme::Themes::variants(),
+        help = "Specifies the theme to use"
+    )]
+    theme: theme::Themes,
+}
+
 fn main() {
-    let matches = App::new("Macchina")
-        .version(VERSION)
-        .author(crate_authors!())
-        .arg(
-            Arg::with_name("palette")
-                .short("p")
-                .long("palette")
-                .multiple(false),
-        )
-        .arg(
-            Arg::with_name("padding")
-                .short("-P")
-                .validator(extra::is_int)
-                .long("padding")
-                .takes_value(true)
-                .multiple(false),
-        )
-        .arg(
-            Arg::with_name("spacing")
-                .short("-s")
-                .validator(extra::is_int)
-                .long("spacing")
-                .takes_value(true)
-                .multiple(false),
-        )
-        .arg(
-            Arg::with_name("no-color")
-                .short("n")
-                .long("no-color")
-                .multiple(false),
-        )
-        .arg(
-            Arg::with_name("color")
-                .short("c")
-                .long("color")
-                .takes_value(true)
-                .multiple(false)
-                .max_values(1)
-                .possible_values(&[
-                    "red", "green", "blue", "yellow", "cyan", "magenta", "black", "white",
-                ]),
-        )
-        .arg(Arg::with_name("bar").short("b").long("bar").multiple(false))
-        .arg(
-            Arg::with_name("separator-color")
-                .short("C")
-                .long("separator-color")
-                .takes_value(true)
-                .multiple(false)
-                .max_values(1)
-                .possible_values(&[
-                    "red", "green", "blue", "yellow", "cyan", "magenta", "black", "white",
-                ]),
-        )
-        .arg(
-            Arg::with_name("random-color")
-                .short("r")
-                .long("random-color")
-                .multiple(false),
-        )
-        .arg(
-            Arg::with_name("random-sep-color")
-                .short("R")
-                .long("random-sep-color")
-                .multiple(false),
-        )
-        .arg(
-            Arg::with_name("hide")
-                .short("H")
-                .long("hide")
-                .takes_value(true)
-                .min_values(1)
-                .max_values(12)
-                .multiple(false)
-                .possible_values(&[
-                    "host", "mach", "distro", "de", "wm", "kernel", "pkgs", "shell", "term", "cpu",
-                    "up", "mem", "bat",
-                ]),
-        )
-        .arg(
-            Arg::with_name("show-only")
-                .short("X")
-                .long("show-only")
-                .takes_value(true)
-                .min_values(1)
-                .max_values(12)
-                .multiple(false)
-                .possible_values(&[
-                    "host", "mach", "distro", "de", "wm", "kernel", "pkgs", "shell", "term", "cpu",
-                    "up", "mem", "bat",
-                ]),
-        )
-        .arg(
-            Arg::with_name("theme")
-                .short("t")
-                .long("theme")
-                .takes_value(true)
-                .max_values(1)
-                .multiple(false)
-                .possible_values(&["H", "He", "Li"]),
-        )
-        .arg(
-            Arg::with_name("short-shell")
-                .short("S")
-                .long("short-shell")
-                .multiple(false),
-        )
-        .arg(
-            Arg::with_name("short-uptime")
-                .short("U")
-                .long("short-uptime")
-                .multiple(false),
-        )
-        .arg(
-            Arg::with_name("debug")
-                .short("d")
-                .long("debug")
-                .multiple(false),
-        )
-        .arg(Arg::with_name("help").short("h").long("help"))
-        .arg(Arg::with_name("version").short("v").long("version"))
-        .get_matches();
+    let opt = Opt::from_args();
 
     // Instantiate Macchina's elements.
     let mut elems = Elements::new();
     let mut fail = Fail::new();
-    elems.set_theme(theme::HydrogenTheme::new(), &mut fail);
+    elems.set_theme(opt.theme.create_instance(), &mut fail);
 
-    if !matches.is_present("theme") {
-        elems.theme.misc_mut().longest_key = elems.longest_key(&mut fail);
+    let mut misc = elems.theme.misc_mut();
+
+
+    misc.padding = opt.padding;
+    misc.color = opt.color.get_color();
+    misc.separator_color = opt.separator_color.get_color();
+
+    if let Some(spacing) = opt.spacing {
+        misc.spacing = spacing;
     }
 
-    // Instantiate Macchina's default behavior, i.e:
-    //   color: enabled
-    //   palette: disabled
-    //   shell shorthand: disabled
-    //   uptime shorthand: disabled
-    let mut opts = Options::new();
-
-    if matches.is_present("palette") {
-        opts.palette_status = true;
-    }
-    if matches.is_present("padding") {
-        elems.theme.misc_mut().padding = matches.value_of("padding").unwrap().parse().unwrap();
-    }
-    if matches.is_present("spacing") {
-        elems.theme.misc_mut().spacing = matches.value_of("spacing").unwrap().parse().unwrap();
-    }
-    if matches.is_present("color") {
-        let color: Color = choose_color(matches.value_of("color").unwrap());
-        elems.theme.misc_mut().color = color;
-    }
-    if matches.is_present("separator-color") {
-        let color: Color = choose_color(matches.value_of("separator-color").unwrap());
-        elems.theme.misc_mut().separator_color = color;
-    }
-    if matches.is_present("short-shell") {
-        opts.shell_shorthand = true;
-    }
-    if matches.is_present("short-uptime") {
-        opts.uptime_shorthand = true;
-    }
-    if matches.is_present("no-color") {
-        let mut misc = elems.theme.misc_mut();
+    if opt.no_color {
         misc.color = Color::White;
         misc.separator_color = Color::White;
     }
-    if matches.is_present("bar") {
-        opts.bar_status = true;
+
+    if let Some(ref elements_to_hide) = opt.hide {
+        display::hide(elems, &opt, &mut fail, elements_to_hide);
+        std::process::exit(0); //todo: refactor, don't make display::hide() also print_info...
     }
-    if matches.is_present("hide") {
-        let elements_to_hide: Vec<&str> = matches.values_of("hide").unwrap().collect();
-        display::hide(elems, opts, &mut fail, elements_to_hide);
-        std::process::exit(0);
-    }
-    if matches.is_present("show-only") {
+
+    if let Some(ref show_only) = opt.show_only {
         elems.hide_all();
-        let elements_to_unhide: Vec<&str> = matches.values_of("show-only").unwrap().collect();
-        display::unhide(elems, opts, &mut fail, elements_to_unhide);
-        std::process::exit(0);
+        display::unhide(elems, &opt, &mut fail, show_only);
+        std::process::exit(0); //todo: refactor, don't make display::unhide() also print_info...
     }
-    if matches.is_present("debug") {
-        elems.init_elements_for_debug(&mut fail, &opts);
+
+    if opt.debug {
+        elems.init_elements_for_debug(&mut fail, &opt);
         display::debug(&mut fail);
         std::process::exit(0);
     }
-    if matches.is_present("help") {
-        display::help();
-        std::process::exit(0);
-    }
-    if matches.is_present("version") {
-        println!("Macchina v{}", VERSION);
-        std::process::exit(0);
-    }
-    if matches.is_present("random-color") {
-        elems.theme.misc_mut().color = display::randomize_color();
-    }
-    if matches.is_present("random-sep-color") {
-        elems.theme.misc_mut().separator_color = display::randomize_color();
-    }
-    if matches.is_present("theme") {
-        if matches.value_of("theme").unwrap() == "He" {
-            elems.set_theme(theme::HeliumTheme::new(), &mut fail)
-        } else if matches.value_of("theme").unwrap() == "Li" {
-            elems.set_theme(theme::LithiumTheme::new(), &mut fail)
-        }
+
+    if opt.random_color {
+        misc.color = display::randomize_color();
     }
 
-    display::print_info(elems, &opts, &mut fail);
+    if opt.random_sep_color {
+        misc.separator_color = display::randomize_color();
+    }
+
+    display::print_info(elems, &opt, &mut fail);
 }

--- a/macchina/src/theme.rs
+++ b/macchina/src/theme.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use colored::{Color, ColoredString, Colorize};
 use std::collections::HashMap;
+use clap::arg_enum;
 
 /// `Misc` contains several elements that make up a `Theme`, such as the: \
 /// - Separator glyph
@@ -88,22 +89,45 @@ impl Bar {
         }
     }
 }
-/// This enum contains all the possible keys, e.g. _Host_, _Machine_, _Kernel_, etc.
-pub enum ReadoutKey {
-    Host,
-    Machine,
-    Kernel,
-    Distribution,
-    OperatingSystem,
-    DesktopEnvironment,
-    WindowManager,
-    Packages,
-    Shell,
-    Terminal,
-    Uptime,
-    Processor,
-    Memory,
-    Battery,
+
+arg_enum! {
+    /// This enum contains all the possible keys, e.g. _Host_, _Machine_, _Kernel_, etc.
+    #[derive(Debug, PartialEq)]
+    pub enum ReadoutKey {
+        Host,
+        Machine,
+        Kernel,
+        Distribution,
+        OperatingSystem,
+        DesktopEnvironment,
+        WindowManager,
+        Packages,
+        Shell,
+        Terminal,
+        Uptime,
+        Processor,
+        Memory,
+        Battery,
+    }
+}
+
+arg_enum! {
+    #[derive(Debug, PartialEq)]
+    pub enum Themes {
+        Hydrogen,
+        Helium,
+        Lithium
+    }
+}
+
+impl Themes {
+    pub fn create_instance(&self) -> Box<dyn Theme> {
+        match self {
+            Themes::Hydrogen => HydrogenTheme::new(),
+            Themes::Helium => HeliumTheme::new(),
+            Themes::Lithium => LithiumTheme::new()
+        }
+    }
 }
 
 /// Defines the different ways a key can be named, let's take the _OperatingSystem variant_ for example: \

--- a/macchina/src/theme.rs
+++ b/macchina/src/theme.rs
@@ -248,6 +248,10 @@ pub trait Theme {
         }
     }
 
+    fn get_colored_separator(&self) -> ColoredString {
+        ColoredString::from(self.misc().separator).color(self.misc().separator_color)
+    }
+
     fn key_to_colored_string(&self, readout_key: ReadoutKey) -> ColoredString {
         let key_name = self.key(readout_key, self.default_abbreviation());
         ColoredString::from(key_name)


### PR DESCRIPTION
This PR adds a type-safe type parsing, which will automatically generate the help / version messages.

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/7266447/111348834-defd2500-8680-11eb-83e9-63f8153b622e.png">

The "possible values" are read from an enum, so when the user executes Macchina, we always get a valid value. Otherwise, the parser will send an error back to the user that the input was invalid:

<img width="520" alt="image" src="https://user-images.githubusercontent.com/7266447/111348978-048a2e80-8681-11eb-89c9-15f332c44dc6.png">
