### PR TITLE
🔨 Fix -X and similar out of bounds error

### DIFF
--- a/macchina/src/main.rs
+++ b/macchina/src/main.rs
@@ -129,7 +129,8 @@ pub struct Opt {
         long = "hide",
         possible_values = &theme::ReadoutKey::variants(),
         case_insensitive = true,
-        help = "Hides the specified elements"
+        help = "Hides the specified elements",
+        min_values = 1
     )]
     hide: Option<Vec<theme::ReadoutKey>>,
 
@@ -138,7 +139,8 @@ pub struct Opt {
         long = "show-only",
         possible_values = &theme::ReadoutKey::variants(),
         case_insensitive = true,
-        help = " Displays only the specified elements"
+        help = " Displays only the specified elements",
+        min_values = 1
     )]
     show_only: Option<Vec<theme::ReadoutKey>>,
 


### PR DESCRIPTION
Fixes an out of bounds error by making -X and --hide require at least one value if the flag is given.