### PR TITLE
⚡️ improve performance of shared::get_meminfo_value()

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ _Macchina_ is pretty fast, see for yourself!
 ## 🐧 Linux
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `macchina` | 34.3 ± 0.8 | 32.9 | 35.9 | 1.00 |
-| `neofetch` | 369.0 ± 3.3 | 362.9 | 376.1 | 10.77 ± 0.26 |
+| `macchina` | 24.7 ± 0.6 | 23.7 | 26.3 | 1.00 |
+| `neofetch` | 373.4 ± 3.8 | 367.3 | 385.9 | 15.10 ± 0.39 |
 
-__Summary__: `macchina` runs __10.77 ± 0.26__ times __faster__ than `neofetch`
+__Summary__: `macchina` runs __15.10 ± 0.39__ times __faster__ than `neofetch`
 
 ## 👩🏽‍💻 macOS
 

--- a/README_CARGO.md
+++ b/README_CARGO.md
@@ -27,10 +27,10 @@ _Macchina_ is pretty fast, see for yourself!
 ## 🐧 Linux
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `macchina` | 34.3 ± 0.8 | 32.9 | 35.9 | 1.00 |
-| `neofetch` | 369.0 ± 3.3 | 362.9 | 376.1 | 10.77 ± 0.26 |
+| `macchina` | 24.7 ± 0.6 | 23.7 | 26.3 | 1.00 |
+| `neofetch` | 373.4 ± 3.8 | 367.3 | 385.9 | 15.10 ± 0.39 |
 
-__Summary__: `macchina` runs __10.77 ± 0.26__ times __faster__ than `neofetch`
+__Summary__: `macchina` runs __15.10 ± 0.39__ times __faster__ than `neofetch`
 
 ## 👩🏽‍💻 macOS
 

--- a/macchina-read/src/linux/mod.rs
+++ b/macchina-read/src/linux/mod.rs
@@ -173,7 +173,7 @@ impl MemoryReadout for LinuxMemoryReadout {
     }
 
     fn cached(&self) -> Result<u64, ReadoutError> {
-        Ok(crate::shared::get_meminfo_value("^Cached"))
+        Ok(crate::shared::get_meminfo_value("Cached"))
     }
 
     fn reclaimable(&self) -> Result<u64, ReadoutError> {

--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -259,10 +259,11 @@ pub(crate) fn get_meminfo_value(value: &str) -> u64 {
         Ok(content) => {
             let reader = BufReader::new(content);
             for line in reader.lines() {
-                let l = line.unwrap();
-                if l.starts_with(value) {
-                    let s_mem_kb: String = l.chars().filter(|c| c.is_digit(10)).collect();
-                    return s_mem_kb.parse::<u64>().unwrap_or(0);
+                if let Ok(l) = line {
+                    if l.starts_with(value) {
+                        let s_mem_kb: String = l.chars().filter(|c| c.is_digit(10)).collect();
+                        return s_mem_kb.parse::<u64>().unwrap_or(0);
+                    }
                 }
             }
             return 0;


### PR DESCRIPTION
This new implementation improves the execution time by at least 10ms, by not relying on _grep_ to get memory values from `/proc/meminfo`