### PR TITLE
⚡ no longer query pacman to get number of installed packages

### DIFF
--- a/macchina-read/src/linux/mod.rs
+++ b/macchina-read/src/linux/mod.rs
@@ -244,6 +244,18 @@ impl PackageReadout for LinuxPackageReadout {
         // we will try and extract package count by checking
         // if a certain package manager is installed
         if extra::which("pacman") {
+            use std::fs::read_dir;
+            use std::path::Path;
+
+            let pacman_folder = Path::new("/var/lib/pacman/local");
+
+            if pacman_folder.exists() {
+                let pacman_count = match read_dir(pacman_folder) {
+                    Ok(read_dir) => read_dir.count() - 1,
+                    Err(_) => 0,
+                };
+                return Ok(pacman_count.to_string());
+            }
             // Returns the number of installed packages using
             // pacman -Qq | wc -l
             let pacman_output = Command::new("pacman")


### PR DESCRIPTION
A new implementation has been added for _Arch-based distributions_, very similar to macOS's homebrew implementation, which returns the number of directories (each program is a directory) of `/var/lib/pacman/local`. The older implementation still remains in the codebase as a fallback.

This shows a **~3ms** improvement in _Macchina's_ execution time.

I'll try and do this for all package managers so _Macchina_ relies less and less on commands, easily becoming the fastest kid on the block!
