### PR TITLE
⚡ faster CPU info extraction

### DIFF
--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -222,33 +222,25 @@ pub(crate) fn shell(shorthand: bool) -> Result<String, ReadoutError> {
 /// Read processor information from `/proc/cpuinfo`
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 pub(crate) fn cpu_model_name() -> String {
-    let grep = Command::new("grep")
-        .arg("model name")
-        .arg("/proc/cpuinfo")
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("ERROR: failed to spawn \"grep\" process");
-
-    let grep_out = grep.stdout.expect("ERROR: failed to open \"grep\" stdout");
-
-    let head = Command::new("head")
-        .args(&["-n", "1"])
-        .stdin(Stdio::from(grep_out))
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("ERROR: failed to spawn \"head\" process");
-
-    let output = head
-        .wait_with_output()
-        .expect("ERROR: failed to wait for \"head\" process to exit");
-    let mut cpu = String::from_utf8(output.stdout)
-        .expect("ERROR: \"head\" process output was not valid UTF-8");
-    cpu = cpu
-        .replace("model name", "")
-        .replace(":", "")
-        .trim()
-        .to_string();
-    cpu
+    let file = fs::File::open("/proc/cpuinfo");
+    match file {
+        Ok(content) => {
+            let reader = BufReader::new(content);
+            for line in reader.lines() {
+                if let Ok(l) = line {
+                    if l.starts_with("model name") {
+                        return l
+                            .replace("model name", "")
+                            .replace(":", "")
+                            .trim()
+                            .to_string();
+                    }
+                }
+            }
+            return String::new();
+        }
+        Err(_e) => String::new(),
+    }
 }
 
 /// Obtain the value of a specified field from `/proc/meminfo` needed to calculate memory usage

--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -1,6 +1,5 @@
 #[allow(dead_code)]
 use crate::traits::ReadoutError;
-use std::io::{BufRead, BufReader};
 
 use std::ffi::CStr;
 use std::io::Error;
@@ -222,6 +221,7 @@ pub(crate) fn shell(shorthand: bool) -> Result<String, ReadoutError> {
 /// Read processor information from `/proc/cpuinfo`
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 pub(crate) fn cpu_model_name() -> String {
+    use std::io::{BufRead, BufReader};
     let file = fs::File::open("/proc/cpuinfo");
     match file {
         Ok(content) => {
@@ -246,6 +246,7 @@ pub(crate) fn cpu_model_name() -> String {
 /// Obtain the value of a specified field from `/proc/meminfo` needed to calculate memory usage
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 pub(crate) fn get_meminfo_value(value: &str) -> u64 {
+    use std::io::{BufRead, BufReader};
     let file = fs::File::open("/proc/meminfo");
     match file {
         Ok(content) => {

--- a/macchina/src/display.rs
+++ b/macchina/src/display.rs
@@ -239,7 +239,11 @@ impl Elements {
             keys.push(self.theme.key(ReadoutKey::Terminal, abbrev).to_string());
         }
         if !self.operating_system.hidden {
-            keys.push(self.theme.key(ReadoutKey::OperatingSystem, abbrev).to_string());
+            keys.push(
+                self.theme
+                    .key(ReadoutKey::OperatingSystem, abbrev)
+                    .to_string(),
+            );
         }
         if !self.processor.hidden {
             keys.push(self.theme.key(ReadoutKey::Processor, abbrev).to_string());
@@ -988,7 +992,7 @@ pub fn hide(
     mut elems: Elements,
     options: &Opt,
     fail: &mut Fail,
-    hide_parameters: &Vec<theme::ReadoutKey>,
+    hide_parameters: &[theme::ReadoutKey],
 ) {
     // We hide the keys the user asked to hide
     elems.host.hidden = hide_parameters.contains(&ReadoutKey::Host);
@@ -1017,7 +1021,7 @@ pub fn unhide(
     mut elems: Elements,
     options: &Opt,
     fail: &mut Fail,
-    hide_parameters: &Vec<theme::ReadoutKey>,
+    hide_parameters: &[theme::ReadoutKey],
 ) {
     // We unhide the keys the user asked to show
     elems.host.hidden = !hide_parameters.contains(&ReadoutKey::Host);
@@ -1034,10 +1038,12 @@ pub fn unhide(
     elems.battery.hidden = !hide_parameters.contains(&ReadoutKey::Battery);
 
     if let Some(true) = elems.is_running_wm_only(fail, false) {
-        elems.desktop_environment.hidden = hide_parameters.contains(&ReadoutKey::DesktopEnvironment);
+        elems.desktop_environment.hidden =
+            hide_parameters.contains(&ReadoutKey::DesktopEnvironment);
         elems.window_manager.hidden = !hide_parameters.contains(&ReadoutKey::WindowManager);
     } else {
-        elems.desktop_environment.hidden = !hide_parameters.contains(&ReadoutKey::DesktopEnvironment);
+        elems.desktop_environment.hidden =
+            !hide_parameters.contains(&ReadoutKey::DesktopEnvironment);
         elems.window_manager.hidden = !hide_parameters.contains(&ReadoutKey::WindowManager);
     }
 

--- a/macchina/src/theme.rs
+++ b/macchina/src/theme.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
+use clap::arg_enum;
 use colored::{Color, ColoredString, Colorize};
 use std::collections::HashMap;
-use clap::arg_enum;
 
 /// `Misc` contains several elements that make up a `Theme`, such as the: \
 /// - Separator glyph
@@ -125,7 +125,7 @@ impl Themes {
         match self {
             Themes::Hydrogen => HydrogenTheme::new(),
             Themes::Helium => HeliumTheme::new(),
-            Themes::Lithium => LithiumTheme::new()
+            Themes::Lithium => LithiumTheme::new(),
         }
     }
 }


### PR DESCRIPTION
This brings a much needed change: _CPU_ information no longer runs any commands to get your processor model.
And marks another step at optimizing most of the program on GNU/Linux and NetBSD.

This shows a __~2ms__ improvement in Macchina's execution time.