### PR TITLE
NetBSD battery fetching improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +242,7 @@ dependencies = [
  "mach",
  "nix",
  "os-release",
+ "regex",
  "sqlite",
  "sysctl",
  "windows",
@@ -247,6 +257,12 @@ checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "miniz_oxide"
@@ -388,6 +404,23 @@ checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
 ]
+
+[[package]]
+name = "regex"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "rustc-demangle"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ The [usage wiki page](https://github.com/grtcdr/macchina/wiki/Usage) can tell yo
 - __Gentoo Only:__ `portage-utils`
 ## 🚩 NetBSD:
 - `wmctrl`
-- `ripgrep`
 
 The [dependencies wiki page](https://github.com/grtcdr/macchina/wiki/Dependencies) explains why these dependencies exist.
 

--- a/README_CARGO.md
+++ b/README_CARGO.md
@@ -100,7 +100,6 @@ The [usage wiki page](https://github.com/grtcdr/macchina/wiki/Usage) can tell yo
 - __Gentoo Only:__ `portage-utils`
 ## 🚩 NetBSD:
 - `wmctrl`
-- `ripgrep`
 
 The [dependencies wiki page](https://github.com/grtcdr/macchina/wiki/Dependencies) explains why these dependencies exist.
 

--- a/macchina-read/Cargo.toml
+++ b/macchina-read/Cargo.toml
@@ -17,7 +17,7 @@ local_ipaddress = "0.1.3"
 
 [target.'cfg(target_os = "netbsd")'.dependencies]
 nix = "0.20.0"
-regex = "1"
+regex = "1.4.5"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 windows = "0.4.0"

--- a/macchina-read/Cargo.toml
+++ b/macchina-read/Cargo.toml
@@ -17,6 +17,7 @@ local_ipaddress = "0.1.3"
 
 [target.'cfg(target_os = "netbsd")'.dependencies]
 nix = "0.20.0"
+regex = "1"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 windows = "0.4.0"

--- a/macchina-read/src/netbsd/mod.rs
+++ b/macchina-read/src/netbsd/mod.rs
@@ -38,8 +38,14 @@ impl BatteryReadout for NetBSDBatteryReadout {
                 let caps = re.captures(&envstat_out);
                 match caps {
                     Some(c) => {
-                        let percentage = c.get(1).map_or("", |m| m.as_str());
-                        return Ok(percentage.to_string().replace("%", ""));
+                        let percentage = c
+                            .get(1)
+                            .map_or("", |m| m.as_str())
+                            .to_string()
+                            .replace("%", "");
+                        let percentage_f = percentage.parse::<f32>().unwrap();
+                        let percentage_i = ((percentage_f / 100_000.0) as i64) * 100_000;
+                        return Ok(percentage_i.to_string());
                     }
                     None => return Err(ReadoutError::MetricNotAvailable),
                 }

--- a/macchina-read/src/netbsd/mod.rs
+++ b/macchina-read/src/netbsd/mod.rs
@@ -57,33 +57,25 @@ impl BatteryReadout for NetBSDBatteryReadout {
     }
 
     fn status(&self) -> Result<String, ReadoutError> {
-        if extra::which("rg") {
+        if extra::which("envstat") {
+            let mut status = String::new();
             let envstat = Command::new("envstat")
                 .args(&["-d", "acpibat0"])
                 .stdout(Stdio::piped())
-                .spawn()
+                .output()
                 .expect("ERROR: failed to spawn \"envstat\" process");
 
-            let envstat_out = envstat
-                .stdout
-                .expect("ERROR: failed to open \"envstat\" stdout");
+            let envstat_out = String::from_utf8(envstat.stdout)
+                .expect("ERROR: \"envstat\" process stdout was not valid UTF-8");
 
-            let rg = Command::new("rg")
-                .arg("charging:")
-                .stdin(Stdio::from(envstat_out))
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .spawn()
-                .expect("ERROR: failed to spawn \"rg\" process");
-
-            let output = rg
-                .wait_with_output()
-                .expect("ERROR: failed to wait for \"rg\" process to exit");
-            let mut status = String::from_utf8(output.stdout)
-                .expect("ERROR: \"grep\" process output was not valid UTF-8");
-            status = status.replace("charging:", "").trim().to_string();
-            if status.is_empty() {
+            if envstat_out.is_empty() {
                 return Err(ReadoutError::MetricNotAvailable);
+            } else {
+                if envstat_out.contains("TRUE") {
+                    status = String::from("TRUE");
+                } else {
+                    status = String::from("FALSE");
+                }
             }
 
             return Ok(status);

--- a/macchina-read/src/netbsd/mod.rs
+++ b/macchina-read/src/netbsd/mod.rs
@@ -44,7 +44,7 @@ impl BatteryReadout for NetBSDBatteryReadout {
                             .to_string()
                             .replace("%", "");
                         let percentage_f = percentage.parse::<f32>().unwrap();
-                        let percentage_i = ((percentage_f / 100_000.0) as i64) * 100_000;
+                        let percentage_i = percentage_f.round() as i32;
                         return Ok(percentage_i.to_string());
                     }
                     None => return Err(ReadoutError::MetricNotAvailable),

--- a/macchina-read/src/netbsd/mod.rs
+++ b/macchina-read/src/netbsd/mod.rs
@@ -1,7 +1,7 @@
 use crate::extra;
 use crate::traits::*;
 use nix::unistd;
-use regex;
+use regex::Regex;
 use std::process::{Command, Stdio};
 
 pub struct NetBSDBatteryReadout;
@@ -35,9 +35,9 @@ impl BatteryReadout for NetBSDBatteryReadout {
                 return Err(ReadoutError::MetricNotAvailable);
             } else {
                 let re = Regex::new(r"/\(([^)]+)\)/").unwrap();
-                let caps = re.captures(envstat_out).unwrap();
+                let caps = re.captures(&envstat_out).unwrap();
                 let percentage = caps.get(1).map_or("", |m| m.as_str());
-                return Ok(percentage);
+                return Ok(percentage.to_string());
             }
         }
 
@@ -59,9 +59,9 @@ impl BatteryReadout for NetBSDBatteryReadout {
                 return Err(ReadoutError::MetricNotAvailable);
             } else {
                 if envstat_out.contains("TRUE") {
-                    return Ok("TRUE");
+                    return Ok(String::from("TRUE"));
                 } else {
-                    return Ok("FALSE");
+                    return Ok(String::from("FALSE"));
                 }
             }
         }

--- a/macchina-read/src/netbsd/mod.rs
+++ b/macchina-read/src/netbsd/mod.rs
@@ -34,10 +34,15 @@ impl BatteryReadout for NetBSDBatteryReadout {
             if envstat_out.is_empty() {
                 return Err(ReadoutError::MetricNotAvailable);
             } else {
-                let re = Regex::new(r"/\(([^)]+)\)/").unwrap();
-                let caps = re.captures(&envstat_out).unwrap();
-                let percentage = caps.get(1).map_or("", |m| m.as_str());
-                return Ok(percentage.to_string());
+                let re = Regex::new(r"\(([^()]*)\)").unwrap();
+                let caps = re.captures(&envstat_out);
+                match caps {
+                    Some(c) => {
+                        let percentage = c.get(1).map_or("", |m| m.as_str());
+                        return Ok(percentage.to_string());
+                    }
+                    None => return Err(ReadoutError::MetricNotAvailable),
+                }
             }
         }
 

--- a/macchina-read/src/netbsd/mod.rs
+++ b/macchina-read/src/netbsd/mod.rs
@@ -39,7 +39,7 @@ impl BatteryReadout for NetBSDBatteryReadout {
                 match caps {
                     Some(c) => {
                         let percentage = c.get(1).map_or("", |m| m.as_str());
-                        return Ok(percentage.to_string());
+                        return Ok(percentage.to_string().replace("%", ""));
                     }
                     None => return Err(ReadoutError::MetricNotAvailable),
                 }


### PR DESCRIPTION
This pull request removes the `rg` depedency required on NetBSD systems, as invoking `rg` costs Macchina around 100ms.