### PR TITLE
Fix clippy warning.

### DIFF
--- a/src/widgets/readout.rs
+++ b/src/widgets/readout.rs
@@ -236,7 +236,7 @@ impl<'a> ReadoutList<'a> {
         *height += area.height + 1;
     }
 
-    fn keys_to_text(&self, theme: &Theme) -> HashMap<ReadoutKey, Text> {
+    fn keys_to_text(&self, theme: &Theme) -> HashMap<ReadoutKey, Text<'_>> {
         let style = Style::default().fg(theme.get_key_color());
 
         self.items


### PR DESCRIPTION
While compiling on Debian 13, 
```
clippy 0.1.91 (ed61e7d7e2 2025-11-07)
```
raises a warning 

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/widgets/readout.rs:239:21
    |
239 |     fn keys_to_text(&self, theme: &Theme) -> HashMap<ReadoutKey, Text> {
    |                     ^^^^^ the lifetime is elided here            ^^^^ the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
239 |     fn keys_to_text(&self, theme: &Theme) -> HashMap<ReadoutKey, Text<'_>> {
    |                                                                      ++++
```